### PR TITLE
Added an option to allow stacked bars to draw from the zero line

### DIFF
--- a/src/scripts/charts/bar.js
+++ b/src/scripts/charts/bar.js
@@ -78,9 +78,9 @@
     seriesBarDistance: 15,
     // If set to true this property will cause the series bars to be stacked. The default stack mode is `accumulate`.
     stackBars: false,  
-    // If set to 'accumulate' this property will force the stacked bars to draw from the zero line.
-    // If set to 'overlap' this property will form a total for each series point. This will also influence the y-axis and the overall bounds of the chart. In stacked mode the seriesBarDistance property will have no effect.
-    stackMode: 'overlap',
+    // If set to 'overlap' this property will force the stacked bars to draw from the zero line.
+    // If set to 'accumulate' this property will form a total for each series point. This will also influence the y-axis and the overall bounds of the chart. In stacked mode the seriesBarDistance property will have no effect.
+    stackMode: 'accumulate',
     // Inverts the axes of the bar chart in order to draw a horizontal bar chart. Be aware that you also need to invert your axis settings as the Y Axis will now display the labels and the X Axis the values.
     horizontalBars: false,
     // If set to true then each bar will represent a series and the data array is expected to be a one dimensional array of data values rather than a series array of series. This is useful if the bar chart should represent a profile rather than some data over time.
@@ -324,16 +324,16 @@
         positions[labelAxis.units.pos + '1'] = projected[labelAxis.units.pos];
         positions[labelAxis.units.pos + '2'] = projected[labelAxis.units.pos];
         
-        if(options.stackBars && options.stackMode == 'overlap') {
-          // Stack mode: overlap (default)
+        if(options.stackBars && (options.stackMode == 'accumulate' || !options.stackMode)) {
+          // Stack mode: accumulate (default)
           // If bars are stacked we use the stackedBarValues reference and otherwise base all bars off the zero line
           // We want backwards compatibility, so the expected fallback without the 'stackMode' option 
-          // should be the original (overlap)
+          // to be the original behaviour (accumulate)
           positions[labelAxis.counterUnits.pos + '1'] = previousStack;
           positions[labelAxis.counterUnits.pos + '2'] = stackedBarValues[valueIndex];
         } else {          
           // Draw from the zero line normally
-          // This is also the same code for Stack mode: accumulate
+          // This is also the same code for Stack mode: overlap
           positions[labelAxis.counterUnits.pos + '1'] = zeroPoint;
           positions[labelAxis.counterUnits.pos + '2'] = projected[labelAxis.counterUnits.pos];        
         }

--- a/src/scripts/charts/bar.js
+++ b/src/scripts/charts/bar.js
@@ -76,10 +76,11 @@
     },
     // Specify the distance in pixel of bars in a group
     seriesBarDistance: 15,
-    // If set to true this property will cause the series bars to be stacked and form a total for each series point. This will also influence the y-axis and the overall bounds of the chart. In stacked mode the seriesBarDistance property will have no effect.
+    // If set to true this property will cause the series bars to be stacked. The default stack mode is `accumulate`.
     stackBars: false,  
-    // If set to true this property will cause the series bars to be stacked and force all bars to draw from the zero line.
-    negativeStackBars: false,
+    // If set to 'accumulate' this property will force the stacked bars to draw from the zero line.
+    // If set to 'overlap' this property will form a total for each series point. This will also influence the y-axis and the overall bounds of the chart. In stacked mode the seriesBarDistance property will have no effect.
+    stackMode: 'overlap',
     // Inverts the axes of the bar chart in order to draw a horizontal bar chart. Be aware that you also need to invert your axis settings as the Y Axis will now display the labels and the X Axis the values.
     horizontalBars: false,
     // If set to true then each bar will represent a series and the data array is expected to be a one dimensional array of data values rather than a series array of series. This is useful if the bar chart should represent a profile rather than some data over time.
@@ -322,9 +323,20 @@
         var positions = {};
         positions[labelAxis.units.pos + '1'] = projected[labelAxis.units.pos];
         positions[labelAxis.units.pos + '2'] = projected[labelAxis.units.pos];
-        // If bars are stacked we use the stackedBarValues reference and otherwise base all bars off the zero line
-        positions[labelAxis.counterUnits.pos + '1'] = options.stackBars && !options.negativeStackBars ? previousStack : zeroPoint;
-        positions[labelAxis.counterUnits.pos + '2'] = options.stackBars && !options.negativeStackBars ? stackedBarValues[valueIndex] : projected[labelAxis.counterUnits.pos];
+        
+        if(options.stackBars && options.stackMode == 'overlap') {
+          // Stack mode: overlap (default)
+          // If bars are stacked we use the stackedBarValues reference and otherwise base all bars off the zero line
+          // We want backwards compatibility, so the expected fallback without the 'stackMode' option 
+          // should be the original (overlap)
+          positions[labelAxis.counterUnits.pos + '1'] = previousStack;
+          positions[labelAxis.counterUnits.pos + '2'] = stackedBarValues[valueIndex];
+        } else {          
+          // Draw from the zero line normally
+          // This is also the same code for Stack mode: accumulate
+          positions[labelAxis.counterUnits.pos + '1'] = zeroPoint;
+          positions[labelAxis.counterUnits.pos + '2'] = projected[labelAxis.counterUnits.pos];        
+        }
 
         // Limit x and y so that they are within the chart rect
         positions.x1 = Math.min(Math.max(positions.x1, chartRect.x1), chartRect.x2);

--- a/src/scripts/charts/bar.js
+++ b/src/scripts/charts/bar.js
@@ -77,7 +77,9 @@
     // Specify the distance in pixel of bars in a group
     seriesBarDistance: 15,
     // If set to true this property will cause the series bars to be stacked and form a total for each series point. This will also influence the y-axis and the overall bounds of the chart. In stacked mode the seriesBarDistance property will have no effect.
-    stackBars: false,
+    stackBars: false,  
+    // If set to true this property will cause the series bars to be stacked and force all bars to draw from the zero line.
+    negativeStackBars: false,
     // Inverts the axes of the bar chart in order to draw a horizontal bar chart. Be aware that you also need to invert your axis settings as the Y Axis will now display the labels and the X Axis the values.
     horizontalBars: false,
     // If set to true then each bar will represent a series and the data array is expected to be a one dimensional array of data values rather than a series array of series. This is useful if the bar chart should represent a profile rather than some data over time.
@@ -321,8 +323,8 @@
         positions[labelAxis.units.pos + '1'] = projected[labelAxis.units.pos];
         positions[labelAxis.units.pos + '2'] = projected[labelAxis.units.pos];
         // If bars are stacked we use the stackedBarValues reference and otherwise base all bars off the zero line
-        positions[labelAxis.counterUnits.pos + '1'] = options.stackBars ? previousStack : zeroPoint;
-        positions[labelAxis.counterUnits.pos + '2'] = options.stackBars ? stackedBarValues[valueIndex] : projected[labelAxis.counterUnits.pos];
+        positions[labelAxis.counterUnits.pos + '1'] = options.stackBars && !options.negativeStackBars ? previousStack : zeroPoint;
+        positions[labelAxis.counterUnits.pos + '2'] = options.stackBars && !options.negativeStackBars ? stackedBarValues[valueIndex] : projected[labelAxis.counterUnits.pos];
 
         // Limit x and y so that they are within the chart rect
         positions.x1 = Math.min(Math.max(positions.x1, chartRect.x1), chartRect.x2);

--- a/src/scripts/charts/bar.js
+++ b/src/scripts/charts/bar.js
@@ -324,7 +324,7 @@
         positions[labelAxis.units.pos + '1'] = projected[labelAxis.units.pos];
         positions[labelAxis.units.pos + '2'] = projected[labelAxis.units.pos];
         
-        if(options.stackBars && (options.stackMode == 'accumulate' || !options.stackMode)) {
+        if(options.stackBars && (options.stackMode === 'accumulate' || !options.stackMode)) {
           // Stack mode: accumulate (default)
           // If bars are stacked we use the stackedBarValues reference and otherwise base all bars off the zero line
           // We want backwards compatibility, so the expected fallback without the 'stackMode' option 


### PR DESCRIPTION
This is related to issue: https://github.com/gionkunz/chartist-js/issues/276

<img width="823" alt="screen shot 2015-09-07 at 4 00 22 pm" src="https://cloud.githubusercontent.com/assets/7564255/9710875/92e634ce-5579-11e5-8c38-bf574fca2e27.png">
