### PR TITLE
bugfix finding high & low for stacked bars graph

### DIFF
--- a/src/scripts/charts/bar.js
+++ b/src/scripts/charts/bar.js
@@ -148,8 +148,8 @@
           return value;
         }).reduce(function(prev, curr) {
           return {
-            x: prev.x + (curr && curr.x) || 0,
-            y: prev.y + (curr && curr.y) || 0
+            x: prev.x + (curr && curr.x ? curr.x : 0) ,
+            y: prev.y + (curr && curr.y ? curr.y : 0) 
           };
         }, {x: 0, y: 0});
       });


### PR DESCRIPTION
The `.reduce()` call before finding the high & low was failing when there were `undefined` items in the series. This fixes that. 

Unfortunately I cannot do the proper contributing flow, because I cannot install node-sass because node-gyp fails on my Macbook with M2.